### PR TITLE
Create unit tests for dialog fragment manager

### DIFF
--- a/androidlibrary_lib/build.gradle
+++ b/androidlibrary_lib/build.gradle
@@ -113,6 +113,8 @@ dependencies {
     testImplementation 'androidx.annotation:annotation:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test:core:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
 }
 
 publishing {

--- a/androidlibrary_lib/src/androidTest/AndroidManifest.xml
+++ b/androidlibrary_lib/src/androidTest/AndroidManifest.xml
@@ -5,7 +5,10 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application android:requestLegacyExternalStorage="true">
+    <application
+        android:requestLegacyExternalStorage="true"
+        android:theme="@style/Theme.AppCompat">
+        <activity android:name="org.opendatakit.test_utils.TestActivity" />
     </application>
 
 

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMgerTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMgerTest.java
@@ -1,0 +1,127 @@
+package org.opendatakit.fragment;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.Before;
+import java.util.Random;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import androidx.fragment.app.FragmentManager;
+import androidx.test.core.app.ActivityScenario;
+import org.opendatakit.test_utils.TestActivity;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import org.opendatakit.fragment.AlertNProgessMsgFragmentMger.DialogState;
+
+public class AlertNProgessMsgFragmentMgerTest {
+
+    private static final String APP_NAME = "APP_NAME";
+
+    private static final String ALERT_DIALOG_TAG = "ALERT_DIALOG_TAG";
+    private static final String PROGRESS_DIALOG_TAG = "PROGRESS_DIALOG_TAG";
+
+    private static final String ALERT_DIALOG_TITLE = "ALERT_DIALOG_TITLE";
+    private static final String ALERT_DIALOG_MESSAGE = "ALERT_DIALOG_MESSAGE";
+
+    private static final String PROGRESS_DIALOG_TITLE = "PROGRESS_DIALOG_TITLE";
+    private static final String PROGRESS_DIALOG_MESSAGE = "PROGRESS_DIALOG_TITLE";
+
+    private AlertNProgessMsgFragmentMger systemUnderTest;
+
+    @Rule
+    public ActivityScenarioRule<TestActivity> rule = new ActivityScenarioRule<>(TestActivity.class);
+
+    @Before
+    public void setUp() {
+        systemUnderTest = new AlertNProgessMsgFragmentMger(APP_NAME,
+                ALERT_DIALOG_TAG,
+                PROGRESS_DIALOG_TAG,
+                false,
+                false);
+    }
+
+    @Test
+    public void testNoDialogIsCreated() {
+        assertEquals(DialogState.None, systemUnderTest.getDialogState());
+    }
+
+    @Test
+    public void testAlertDialogIsCreated() {
+        ActivityScenario<TestActivity> scenario = rule.getScenario();
+
+        scenario.onActivity(new ActivityScenario.ActivityAction<TestActivity>() {
+            @Override
+            public void perform(TestActivity activity) {
+                int fragmentId = new Random().nextInt();
+                FragmentManager fragmentManager = activity.getSupportFragmentManager();
+
+                systemUnderTest.createAlertDialog(ALERT_DIALOG_TITLE, ALERT_DIALOG_MESSAGE, fragmentManager, fragmentId);
+                fragmentManager.executePendingTransactions();
+
+                assertThat(fragmentManager.findFragmentByTag(ALERT_DIALOG_TAG).isAdded(), is(true));
+                assertEquals(DialogState.Alert, systemUnderTest.getDialogState());
+                Assert.assertThat(systemUnderTest.hasDialogBeenCreated(), is(true));
+            }
+        });
+    }
+
+    @Test
+    public void testProgressDialogIsCreated() {
+        ActivityScenario<TestActivity> scenario = rule.getScenario();
+
+        scenario.onActivity(new ActivityScenario.ActivityAction<TestActivity>() {
+            @Override
+            public void perform(TestActivity activity) {
+                FragmentManager fragmentManager = activity.getSupportFragmentManager();
+
+                systemUnderTest.createProgressDialog(PROGRESS_DIALOG_TITLE, PROGRESS_DIALOG_MESSAGE, fragmentManager);
+                fragmentManager.executePendingTransactions();
+
+                assertThat(fragmentManager.findFragmentByTag(PROGRESS_DIALOG_TAG).isAdded(), is(true));
+                assertEquals(DialogState.Progress, systemUnderTest.getDialogState());
+                Assert.assertThat(systemUnderTest.hasDialogBeenCreated(), is(true));
+            }
+        });
+    }
+
+    @Test
+    public void testProgressDialogIsDismissed() {
+        ActivityScenario<TestActivity> scenario = rule.getScenario();
+
+        scenario.onActivity(new ActivityScenario.ActivityAction<TestActivity>() {
+            @Override
+            public void perform(TestActivity activity) {
+                FragmentManager fragmentManager = activity.getSupportFragmentManager();
+
+                systemUnderTest.createProgressDialog(PROGRESS_DIALOG_TITLE, PROGRESS_DIALOG_MESSAGE, fragmentManager);
+                fragmentManager.executePendingTransactions();
+                systemUnderTest.dismissProgressDialog(fragmentManager);
+
+                assertEquals(DialogState.None, systemUnderTest.getDialogState());
+                Assert.assertThat(systemUnderTest.hasDialogBeenCreated(), is(false));
+            }
+        });
+    }
+
+    @Test
+    public void testAlertDialogIsDismissed() {
+        ActivityScenario<TestActivity> scenario = rule.getScenario();
+
+        scenario.onActivity(new ActivityScenario.ActivityAction<TestActivity>() {
+            @Override
+            public void perform(TestActivity activity) {
+                int fragmentId = new Random().nextInt();
+                FragmentManager fragmentManager = activity.getSupportFragmentManager();
+
+                systemUnderTest.createAlertDialog(ALERT_DIALOG_TITLE, ALERT_DIALOG_MESSAGE, fragmentManager, fragmentId);
+                fragmentManager.executePendingTransactions();
+                systemUnderTest.dismissAlertDialog(fragmentManager);
+
+                assertEquals(DialogState.None, systemUnderTest.getDialogState());
+                Assert.assertThat(systemUnderTest.hasDialogBeenCreated(), is(false));
+            }
+        });
+    }
+}

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMgerTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMgerTest.java
@@ -45,6 +45,7 @@ public class AlertNProgessMsgFragmentMgerTest {
     @Test
     public void testNoDialogIsCreated() {
         assertEquals(DialogState.None, systemUnderTest.getDialogState());
+        Assert.assertThat(systemUnderTest.hasDialogBeenCreated(), is(false));
     }
 
     @Test

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMgerTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMgerTest.java
@@ -45,7 +45,6 @@ public class AlertNProgessMsgFragmentMgerTest {
     @Test
     public void testNoDialogIsCreated() {
         assertEquals(DialogState.None, systemUnderTest.getDialogState());
-        Assert.assertThat(systemUnderTest.hasDialogBeenCreated(), is(false));
     }
 
     @Test
@@ -101,7 +100,6 @@ public class AlertNProgessMsgFragmentMgerTest {
                 systemUnderTest.dismissProgressDialog(fragmentManager);
 
                 assertEquals(DialogState.None, systemUnderTest.getDialogState());
-                Assert.assertThat(systemUnderTest.hasDialogBeenCreated(), is(false));
             }
         });
     }
@@ -121,7 +119,6 @@ public class AlertNProgessMsgFragmentMgerTest {
                 systemUnderTest.dismissAlertDialog(fragmentManager);
 
                 assertEquals(DialogState.None, systemUnderTest.getDialogState());
-                Assert.assertThat(systemUnderTest.hasDialogBeenCreated(), is(false));
             }
         });
     }

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/test_utils/TestActivity.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/test_utils/TestActivity.java
@@ -1,0 +1,18 @@
+package org.opendatakit.test_utils;
+
+import android.content.Context;
+import androidx.appcompat.app.AppCompatActivity;
+import org.opendatakit.activities.IAppAwareActivity;
+
+public class TestActivity extends AppCompatActivity implements IAppAwareActivity {
+
+    @Override
+    public String getAppName() {
+        return "TEST_APP_NAME";
+    }
+
+    @Override
+    public Context getApplicationContext() {
+        return getApplication().getApplicationContext();
+    }
+}

--- a/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMger.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMger.java
@@ -186,10 +186,14 @@ public class AlertNProgessMsgFragmentMger {
          break;
       default:
       case None:
-         return true;
+         return false;
       }
      return false;
    }
+
+    public DialogState getDialogState() {
+        return mDialogState;
+    }
 
    public void clearDialogsAndRetainCurrentState(FragmentManager fragmentManager) {
       if (fragmentManager == null) {

--- a/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMger.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMger.java
@@ -186,7 +186,7 @@ public class AlertNProgessMsgFragmentMger {
          break;
       default:
       case None:
-         return false;
+         return true;
       }
      return false;
    }


### PR DESCRIPTION
### Issue Reference
Test `Fragmentmanager`
https://github.com/odk-x/tool-suite-X/issues/305

### Solution and Consideration
First thing to note on the PR is this: The system under test `AlertNProgessMsgFragmentMger` depends on some android framework objects for its functionality. Common one here is the `Fragmentmanager`.
To successfuly test this class, I have had to introduce a test activity class, specifically for the purpose of getting reference to a Fragmentmanager class.  This activity is successfully created in the test code with the help of `ActivityScenario` , which is part of Android core testing framwork.

Also, as part of what i did for this task, I refactored the code at  `AlertNProgessMsgFragmentMger#hasDialogBeenCreated`  to return `false` when the dialog state is `DialogState.None`


### ScreenShot
<img width="1357" alt="Screenshot 2021-10-30 at 01 11 16" src="https://user-images.githubusercontent.com/34775925/139513169-7a581bba-c6aa-429f-9636-c36e386d3cf2.png">

