### PR TITLE
Sets the color of the app status bar to match the app backround

### DIFF
--- a/androidlibrary_lib/src/main/res/values/theme.xml
+++ b/androidlibrary_lib/src/main/res/values/theme.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- ActionBar style -->
     <style name="OdkActionBar"
         parent="Widget.AppCompat.Light.ActionBar.Solid">
@@ -8,13 +8,14 @@
         <item name="logo">@drawable/app_logo</item>
     </style>
 
-    <style name="Opendatakit" parent="Theme.AppCompat.Light">
+    <style name="Opendatakit" parent="Theme.AppCompat.DayNight">
         <item name="android:scrollbarThumbHorizontal">@drawable/thumb</item>
         <item name="android:scrollbarThumbVertical">@drawable/thumb</item>
         <item name="android:scrollbarSize">2.5mm</item>
         <item name="android:scrollbarAlwaysDrawVerticalTrack">true</item>
         <item name="android:scrollbarAlwaysDrawHorizontalTrack">true</item>
         <item name="actionBarStyle">@style/OdkActionBar</item>
+        <item name="android:statusBarColor">@color/white</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 </resources>


### PR DESCRIPTION
This PR sets the app status bar to match the app background and also adds the dark theme for the app bar 

screenshots : 

<img width="864" alt="Screenshot 2022-10-13 at 18 47 21" src="https://user-images.githubusercontent.com/34124778/195669956-c33fc95f-e613-454c-9ac7-7959a30a51dd.png">
<img width="856" alt="Screenshot 2022-10-13 at 18 46 27" src="https://user-images.githubusercontent.com/34124778/195669972-6de71b50-3c07-4653-82f7-161303474e4c.png">
