### PR TITLE
chore : Sets the color of the app status bar to match the app background 

### DIFF
--- a/androidlibrary_lib/src/main/res/values/theme.xml
+++ b/androidlibrary_lib/src/main/res/values/theme.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- ActionBar style -->
     <style name="OdkActionBar"
         parent="Widget.AppCompat.Light.ActionBar.Solid">
@@ -8,13 +8,14 @@
         <item name="logo">@drawable/app_logo</item>
     </style>
 
-    <style name="Opendatakit" parent="Theme.AppCompat.Light">
+    <style name="Opendatakit" parent="Theme.AppCompat.DayNight">
         <item name="android:scrollbarThumbHorizontal">@drawable/thumb</item>
         <item name="android:scrollbarThumbVertical">@drawable/thumb</item>
         <item name="android:scrollbarSize">2.5mm</item>
         <item name="android:scrollbarAlwaysDrawVerticalTrack">true</item>
         <item name="android:scrollbarAlwaysDrawHorizontalTrack">true</item>
         <item name="actionBarStyle">@style/OdkActionBar</item>
+        <item name="android:statusBarColor">@color/white</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 </resources>


### PR DESCRIPTION
This PR sets the app status bar to match the app background and also adds the dark theme for the app bar

screenshots :

<img width="856" alt="Screenshot 2022-10-13 at 18 46 27" src="https://user-images.githubusercontent.com/34124778/195670876-d978fa4d-cd7f-4706-b427
<img width="864" alt="Screenshot 2022-10-13 at 18 47 21" src="https://user-images.githubusercontent.com/34124778/195670893-477c7f5c-c0d8-44e9-9477-3726b5914476.png">
-e44e5569a1bc.png">
