### PR TITLE
Setting The status bar colour

### DIFF
--- a/androidlibrary_lib/src/main/res/values/theme.xml
+++ b/androidlibrary_lib/src/main/res/values/theme.xml
@@ -1,20 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- ActionBar style -->
-    <style name="OdkActionBar"
-        parent="Widget.AppCompat.Light.ActionBar.Solid">
-        <item name="displayOptions">useLogo|showHome|showTitle</item>
-        <item name="background">@color/white</item>
-        <item name="logo">@drawable/app_logo</item>
-    </style>
+<resources> xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.android.com/tools ">
 
-    <style name="Opendatakit" parent="Theme.AppCompat.Light">
-        <item name="android:scrollbarThumbHorizontal">@drawable/thumb</item>
-        <item name="android:scrollbarThumbVertical">@drawable/thumb</item>
-        <item name="android:scrollbarSize">2.5mm</item>
-        <item name="android:scrollbarAlwaysDrawVerticalTrack">true</item>
-        <item name="android:scrollbarAlwaysDrawHorizontalTrack">true</item>
-        <item name="actionBarStyle">@style/OdkActionBar</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
-    </style>
-</resources>
+
+        <!-- ActionBar style -->
+        <style name="OdkActionBar" parent="Widget.AppCompat.Light.ActionBar.Solid">
+            <item name="displayOptions">useLogo|showHome|showTitle</item>
+            <item name="background">@color/white</item>
+            <item name="logo">@drawable/app_logo</item>
+        </style>
+
+        <style name="OdkActionBarDark" parent="Widget.AppCompat.Light.ActionBar.Solid">
+            <item name="displayOptions">useLogo|showHome|showTitle</item>
+            <item name="background">@color/black</item>
+            <item name="android:textColor">@color/white</item>
+            <item name="logo">@drawable/app_logo</item>
+        </style>
+
+        <!-- Light Theme -->
+        <style name="Opendatakit" parent="Theme.AppCompat.Light">
+            <item name="android:scrollbarThumbHorizontal">@drawable/thumb</item>
+            <item name="android:scrollbarThumbVertical">@drawable/thumb</item>
+            <item name="android:scrollbarSize">2.5dp</item>
+            <item name="android:scrollbarAlwaysDrawVerticalTrack">true</item>
+            <item name="android:scrollbarAlwaysDrawHorizontalTrack">true</item>
+            <item name="android:statusBarColor">@color/white</item>
+            <item name="android:windowLightStatusBar">true</item>
+            <item name="actionBarStyle">@style/OdkActionBar</item>
+            <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+        </style>
+    </resources>


### PR DESCRIPTION
I have added a few codes under the themes value to adjust the colour of the status bar so it isn't in contrast with the app background as requested. I ran into errors when i used the navigationbarcolour in the code provided to us, so i had it replaced with statusbarcolour after a few more researches. Attached is an image of it in my android emulator.
![WhatsApp Image 2022-10-24 at 5 10 51 PM](https://user-images.githubusercontent.com/115474999/197574147-5ac3257c-a53a-4491-ae87-4cb9a7f24c12.jpeg)
