### PR TITLE
 update  deprecated instrumented registry 

### DIFF
--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/logic/PropertiesNonPrivilegedTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/logic/PropertiesNonPrivilegedTest.java
@@ -18,7 +18,8 @@ package org.opendatakit.logic;
 import android.Manifest;
 import android.content.Context;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
+
 import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Before;
@@ -48,9 +49,9 @@ public class PropertiesNonPrivilegedTest {
     private static final String APPNAME = "unittestProp";
 
     @Rule
-    public GrantPermissionRule writeRuntimePermissionRule = GrantPermissionRule .grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    public GrantPermissionRule writeRuntimePermissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
     @Rule
-    public GrantPermissionRule readtimePermissionRule = GrantPermissionRule .grant(Manifest.permission.READ_EXTERNAL_STORAGE);
+    public GrantPermissionRule readtimePermissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE);
 
     @Before
     public void setUp() throws Exception {
@@ -64,10 +65,10 @@ public class PropertiesNonPrivilegedTest {
     @Test
     public void testSimpleProperties() {
 
-        Context context = InstrumentationRegistry.getContext();
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         PropertiesSingleton props = CommonToolProperties.get(context, APPNAME);
-        Map<String,String> properties = new HashMap<String,String>();
+        Map<String, String> properties = new HashMap<String, String>();
         // non-default value for font size
         properties.put(CommonToolProperties.KEY_FONT_SIZE, "29");
 
@@ -87,13 +88,13 @@ public class PropertiesNonPrivilegedTest {
     public void testSecureSetProperties() {
 
         StaticStateManipulator.get().reset();
-        Context context = InstrumentationRegistry.getContext();
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        TreeMap<String,String> secureProperties = new TreeMap<String,String>();
+        TreeMap<String, String> secureProperties = new TreeMap<String, String>();
         CommonToolProperties.accumulateProperties(context, null, null, secureProperties);
         PropertiesSingleton props = CommonToolProperties.get(context, APPNAME);
 
-        for ( String secureKey : secureProperties.keySet() ) {
+        for (String secureKey : secureProperties.keySet()) {
             // this is stored in SharedPreferences
             boolean threwError = false;
             try {
@@ -125,13 +126,13 @@ public class PropertiesNonPrivilegedTest {
     public void testSecureGetProperties() {
 
         StaticStateManipulator.get().reset();
-        Context context = InstrumentationRegistry.getContext();
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        TreeMap<String,String> secureProperties = new TreeMap<String,String>();
+        TreeMap<String, String> secureProperties = new TreeMap<String, String>();
         CommonToolProperties.accumulateProperties(context, null, null, secureProperties);
         PropertiesSingleton props = CommonToolProperties.get(context, APPNAME);
 
-        for ( String secureKey : secureProperties.keySet() ) {
+        for (String secureKey : secureProperties.keySet()) {
             // this is stored in SharedPreferences
             // always throws an exception
             boolean threwError = false;


### PR DESCRIPTION
**Pull Request Description:**
- Updated imports to use `androidx.test.platform.app.InstrumentationRegistry` for improved compatibility with modern Android testing practices.
- Refactored code to use `InstrumentationRegistry.getInstrumentation().getTargetContext()` for obtaining the application context instead of deprecated methods.
-This pull request solved the [issuse no. 435 ](https://github.com/odk-x/tool-suite-X/issues/435 
) on  [tool-suite-X](https://github.com/odk-x/tool-suite-X)
**All Test are passed after description** : 
![image](https://github.com/odk-x/androidlibrary/assets/25600880/c2d14706-e957-41c2-97dd-5b53851e0c49)
