### PR TITLE
Update Charsets to StandardCharsets

### DIFF
--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/utilities/FileSetTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/utilities/FileSetTest.java
@@ -27,16 +27,14 @@ import org.opendatakit.logging.desktop.WebLoggerDesktopFactoryImpl;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 
 public class FileSetTest {
   private static final String APP_NAME = "fileSetTest";
   private static final String TABLE_ID_1 = "myTableId_1";
-  private static final String TABLE_ID_2 = "myTableId_2";
   private static final String INSTANCE_ID_1 = "myInstanceId_1";
-  private static final String INSTANCE_ID_2 = "myInstanceId_2";
   private static final String INSTANCE_FILENAME = "submission.xml";
   private static final String FILENAME_1 = "foo.jpg";
   private static final String FILENAME_2 = "bar.wav";
@@ -70,7 +68,7 @@ public class FileSetTest {
 
     String value = fileSet.serializeUriFragmentList();
 
-    ByteArrayInputStream bis = new ByteArrayInputStream(value.getBytes(Charset.forName("UTF-8")));
+    ByteArrayInputStream bis = new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
     FileSet outSet = FileSet.parse(APP_NAME, bis);
 
     assertEquals( fileSet.instanceFile, outSet.instanceFile);


### PR DESCRIPTION
# PR Descriptions

Update Charsets to StandardCharsets to enhance more clean and readable up-to-date code

- Updated code from `ByteArrayInputStream bis = new ByteArrayInputStream(value.getBytes(Charset.forName("UTF-8")));` 
<img width="938" alt="Screenshot 2023-10-26 at 9 34 24 AM" src="https://github.com/odk-x/androidlibrary/assets/107570182/4e98a96d-c77a-49c1-a385-bb7c4f166019">

 to `ByteArrayInputStream bis = new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));` 
<img width="881" alt="Screenshot 2023-10-26 at 9 34 15 AM" src="https://github.com/odk-x/androidlibrary/assets/107570182/3db75acc-04e6-4596-9fcb-583d8e768de6"> <br>

- Run test to be sure everything still works
<img width="604" alt="Screenshot 2023-10-26 at 9 34 00 AM" src="https://github.com/odk-x/androidlibrary/assets/107570182/2bef0a78-00db-4d9d-9dda-b564c5eba4bd"><br>

- Then removed unused constant fields
<img width="595" alt="Screenshot 2023-10-26 at 10 00 03 AM" src="https://github.com/odk-x/androidlibrary/assets/107570182/7d869a55-b18b-415d-9568-4ca849966e26"><br>

- Rerun the test again, everything still works